### PR TITLE
Add `GroupEntityMapperTest` to validate handling of missing members

### DIFF
--- a/server/main/java/com/desertskyrangers/flightdeck/adapter/store/entity/mapper/GroupEntityMapper.java
+++ b/server/main/java/com/desertskyrangers/flightdeck/adapter/store/entity/mapper/GroupEntityMapper.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -44,7 +45,9 @@ public class GroupEntityMapper {
 
 		if( group.members() != null ) {
 			entity.setMemberships( group.members().stream()
-				.map( m -> memberRepo.getReferenceById( m.id() ) )
+				.map( m -> memberRepo.findById( m.id() ) )
+				.filter( Optional::isPresent )
+				.map( Optional::get )
 				.collect( Collectors.toSet() ) );
 		}
 

--- a/server/test/java/com/desertskyrangers/flightdeck/adapter/store/entity/mapper/GroupEntityMapperTest.java
+++ b/server/test/java/com/desertskyrangers/flightdeck/adapter/store/entity/mapper/GroupEntityMapperTest.java
@@ -1,0 +1,64 @@
+package com.desertskyrangers.flightdeck.adapter.store.entity.mapper;
+
+import com.desertskyrangers.flightdeck.adapter.store.entity.GroupEntity;
+import com.desertskyrangers.flightdeck.adapter.store.entity.MemberEntity;
+import com.desertskyrangers.flightdeck.adapter.store.repo.MemberRepo;
+import com.desertskyrangers.flightdeck.adapter.store.repo.UserRepo;
+import com.desertskyrangers.flightdeck.core.model.Group;
+import com.desertskyrangers.flightdeck.core.model.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+class GroupEntityMapperTest {
+
+	private UserRepo userRepo;
+
+	private MemberRepo memberRepo;
+
+	private GroupEntityMapper groupEntityMapper;
+
+	@BeforeEach
+	void setUp() {
+		userRepo = Mockito.mock( UserRepo.class );
+		memberRepo = Mockito.mock( MemberRepo.class );
+		groupEntityMapper = new GroupEntityMapper( userRepo, memberRepo );
+	}
+
+	@Test
+	void testToEntityWithMissingMemberDoesNotThrowException() {
+		// given
+		UUID activeMemberId = UUID.randomUUID();
+		UUID missingMemberId = UUID.randomUUID();
+
+		Member activeMember = new Member().id( activeMemberId );
+		Member missingMember = new Member().id( missingMemberId );
+
+		Group group = new Group()
+			.id( UUID.randomUUID() )
+			.type( Group.Type.GROUP )
+			.name( "Test Group" )
+			.members( Set.of( activeMember, missingMember ) );
+
+		MemberEntity activeMemberEntity = new MemberEntity().setId( activeMemberId );
+
+		// Mock memberRepo to return the active member but return empty for the missing member
+		when( memberRepo.findById( activeMemberId ) ).thenReturn( Optional.of( activeMemberEntity ) );
+		when( memberRepo.findById( missingMemberId ) ).thenReturn( Optional.empty() );
+
+		// when
+		GroupEntity entity = groupEntityMapper.toEntity( group );
+
+		// then
+		assertThat( entity ).isNotNull();
+		assertThat( entity.getMemberships() ).hasSize( 1 );
+		assertThat( entity.getMemberships().iterator().next().getId() ).isEqualTo( activeMemberId );
+	}
+}


### PR DESCRIPTION
…update `GroupEntityMapper` to filter out missing members gracefully during mapping.